### PR TITLE
Changed subprocess.run command in launch_ui function

### DIFF
--- a/src/opyrator/ui/streamlit_ui.py
+++ b/src/opyrator/ui/streamlit_ui.py
@@ -53,7 +53,7 @@ def launch_ui(opyrator_path: str, port: int = 8501) -> None:
             python_path = f"set PYTHONPATH=%PYTHONPATH%;{getcwd()} &&"
 
         subprocess.run(
-            f"{python_path} {sys.executable} -m streamlit run --server.port={port} --server.headless=True --runner.magicEnabled=False --server.maxUploadSize=50 --browser.gatherUsageStats=False {f.name}",
+            f'''{python_path} "{sys.executable}" -m streamlit run --server.port={port} --server.headless=True --runner.magicEnabled=False --server.maxUploadSize=50 --browser.gatherUsageStats=False {f.name}''',
             shell=True,
         )
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] New Feature
- [ ] Feature Improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
I made a change in the subprocess.run command in the launch_ui function. Sys.executable is now in quotes so that it can work with paths that contain spaces. I ran "opyrator launch-ui main:hello_world", main being the file and hello_world being the function on my Windows 10 machine and I get the error "C:/Program is not recognized as an internal or external command, operable program or batch file" since my python installation is located under C:/Program Files/Python39. This PR fixes that issue.

**Checklist:**

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
